### PR TITLE
Fixing line style reading in ass files

### DIFF
--- a/src/Captioning/Format/SubstationalphaFile.php
+++ b/src/Captioning/Format/SubstationalphaFile.php
@@ -230,7 +230,7 @@ class SubstationalphaFile extends File
                 $tmp_styles = array();
                 $tmp = explode(':', $line);
                 if ($tmp[0] !== 'Format') {
-                    throw new \Exception($this->filename . ' is not valid file.');
+                    throw new \Exception($this->filename . ' is not valid file (format line).');
                 }
                 $tmp2 = explode(',', $tmp[1]);
 
@@ -238,12 +238,12 @@ class SubstationalphaFile extends File
                     $tmp_styles[trim($s)] = null;
                 }
 
+                // line Style: ....
                 $line = $this->getNextValueFromArray($fileContentArray);
-                $tmp = explode(':', $line);
-                if ($tmp[0] !== 'Style') {
-                    throw new \Exception($this->filename . ' is not valid file.');
+                if (substr($line, 0, 6) !== "Style:") {
+                    throw new \Exception($this->filename . ' is not valid file (style line).');
                 }
-                $tmp2 = explode(',', $tmp[1]);
+                $tmp2 = explode(',', substr($line, 7));
                 $i = 0;
                 foreach (array_keys($tmp_styles) as $s) {
                     $this->setStyle($s, trim($tmp2[$i]));

--- a/tests/Fixtures/Substationalpha/ass_v4plus_valid.ass
+++ b/tests/Fixtures/Substationalpha/ass_v4plus_valid.ass
@@ -8,6 +8,7 @@ PlayDepth: 0
 [V4+ Styles]
 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
 Style: Default,Arial,20,&H00FFFFFF,&H0300FFFF,&H00000000,&H02000000,0,0,0,0,100,100,0,0,1,2,1,2,10,10,10,1
+Style: Aoi Hana OP,Magic:the Gathering,79,&H00FAEFF2,&H000019FF,&H00DFD0A2,&H00D5A9F8,0,-1,0,0,119.351,100,0,0,1,6.77824,0,8,30,30,56,1
 
 [Events]
 Format: Layer, Start, End, Style, Actor, MarginL, MarginR, MarginV, Effect, Text


### PR DESCRIPTION
If the font name contained a colon, the file was declared incorrect.