### PR TITLE
WebVTT more line terminators fix

### DIFF
--- a/src/Captioning/Format/WebvttFile.php
+++ b/src/Captioning/Format/WebvttFile.php
@@ -1,11 +1,11 @@
 <?php
-
 namespace Captioning\Format;
 
 use Captioning\File;
 
 class WebvttFile extends File
 {
+
     const TIMECODE_PATTERN = '#^((?:[0-9]{2,}:)?[0-9]{2}:[0-9]{2}.[0-9]{3}) --> ((?:[0-9]{2,}:)?[0-9]{2}:[0-9]{2}.[0-9]{3})( .*)?$#';
 
     /**
@@ -40,7 +40,6 @@ class WebvttFile extends File
                 } else {
                     $this->fileDescription = $fileDescription;
                 }
-
             } else {
                 $parsing_errors[] = 'Invalid file header (must be "WEBVTT" with optionnal description)';
             }
@@ -111,6 +110,13 @@ class WebvttFile extends File
                 $note = $id = '';
                 $this->addCue($cue);
                 unset($cue);
+
+                // skip empty lines
+                // see https://www.w3.org/TR/webvtt1/#webvtt-file-bodyhttps://www.w3.org/TR/webvtt1/#webvtt-file-body
+                // point 7
+                while (current($fileContentArray) === '') {
+                    next($fileContentArray);
+                }
             } elseif ($line !== '') {
                 // Supposse what not empty line before timeline is id.
                 $id = $line;

--- a/src/Captioning/Format/WebvttFile.php
+++ b/src/Captioning/Format/WebvttFile.php
@@ -115,6 +115,7 @@ class WebvttFile extends File
                 // see https://www.w3.org/TR/webvtt1/#webvtt-file-bodyhttps://www.w3.org/TR/webvtt1/#webvtt-file-body
                 // point 7
                 while (current($fileContentArray) === '') {
+                    $i++;
                     next($fileContentArray);
                 }
             } elseif ($line !== '') {

--- a/tests/Captioning/Format/WebvttFileTest.php
+++ b/tests/Captioning/Format/WebvttFileTest.php
@@ -31,6 +31,7 @@ class WebvttFileTest extends \PHPUnit_Framework_TestCase
             array('1.3-non-normative_other-features_4.vtt'),
             array('long-hours.vtt'),
             array('empty.vtt'),
+            array('more_line_terminators.vtt'),
         );
     }
 

--- a/tests/Fixtures/WebVTT-2015-10-09/more_line_terminators.vtt
+++ b/tests/Fixtures/WebVTT-2015-10-09/more_line_terminators.vtt
@@ -1,0 +1,17 @@
+WEBVTT
+
+00:10.940 --> 00:20.750
+I'm thinking of the tent audiences that wonderful collection
+
+00:20.940 --> 00:30.750
+I'm thinking of the tent audiences that wonderful collection
+
+
+00:30.940 --> 00:40.750
+I'm thinking of the tent audiences that wonderful collection
+
+
+
+
+00:40.940 --> 00:50.810
+of some of the most effective intelligent intellectual


### PR DESCRIPTION
More WebVTT line terminators fix (see [WebVTT file body](https://www.w3.org/TR/webvtt1/#webvtt-file-body) point 7).

Example:
```
WEBVTT

00:10.940 --> 00:20.750
I'm thinking of the tent audiences that wonderful collection

00:20.940 --> 00:30.750
I'm thinking of the tent audiences that wonderful collection


00:30.940 --> 00:40.750
I'm thinking of the tent audiences that wonderful collection




00:40.940 --> 00:50.810
of some of the most effective intelligent intellectual
```